### PR TITLE
Add genesis_nicole filter

### DIFF
--- a/Nicole/models/conversation.py
+++ b/Nicole/models/conversation.py
@@ -10,6 +10,8 @@ import dataclasses
 from enum import IntEnum, auto
 from typing import Dict, List
 
+from Nicole.utils.genesis_nicole import genesis_nicole
+
 # ─────────────────────── Nicole Unified Prompt ───────────────────────────
 NICOLE_CORE_PROMPT = (
     """
@@ -101,6 +103,18 @@ class Conversation:
     def copy(self):
         return dataclasses.replace(self, messages=[m.copy() for m in self.messages])
 
+    def apply_genesis_filter(self, model, tokenizer, **kwargs):
+        """Run the genesis filter on the last assistant message."""
+        if not self.messages:
+            return None
+        role, msg = self.messages[-1]
+        if role != self.roles[1] or msg is None:
+            return None
+
+        result = genesis_nicole(model, tokenizer, msg, **kwargs)
+        self.messages[-1][1] = result["final_resonance"]
+        return result
+
 
 # ───────────────────────── Template Registry ─────────────────────────────
 conv_templates: Dict[str, Conversation] = {}
@@ -149,3 +163,4 @@ if __name__ == "__main__":
     demo.append_message(demo.roles[0], "Hello Nicole, who are you?")
     demo.append_message(demo.roles[1], None)
     print(demo.get_prompt())
+

--- a/Nicole/utils/genesis_nicole.py
+++ b/Nicole/utils/genesis_nicole.py
@@ -1,0 +1,52 @@
+import torch
+from typing import Dict
+from transformers import PreTrainedModel, PreTrainedTokenizer
+
+
+def genesis_nicole(
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer,
+    initial_prompt: str,
+    *,
+    iterations: int = 3,
+    temperature: float = 0.8,
+    max_new_tokens: int = 150,
+    resonance_threshold: float = 0.7,
+) -> Dict[str, float]:
+    """Apply a recursive resonance loop to refine Nicole's response."""
+
+    messages = [{"role": "user", "content": initial_prompt}]
+    resonances = []
+    prev_output = None
+    sim = 0.0
+    for layer in range(iterations):
+        prompt = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+        input_ids = torch.tensor([prompt]).to(model.device)
+        completion = model.generate(
+            input_ids=input_ids,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            eos_token_id=tokenizer.eos_token_id,
+        )[0]
+        output = tokenizer.decode(completion, skip_special_tokens=True)
+        resonances.append(output)
+
+        if prev_output is not None:
+            embed = model.get_input_embeddings()
+            vec_prev = embed(torch.tensor(tokenizer.encode(prev_output)).to(model.device)).mean(0)
+            vec_curr = embed(torch.tensor(tokenizer.encode(output)).to(model.device)).mean(0)
+            sim = torch.cosine_similarity(vec_prev, vec_curr, dim=0).item()
+            if sim > resonance_threshold:
+                break
+
+        mutate_prompt = (
+            f"{initial_prompt}\nPrevious echo: {output}\nResonate deeper: Rethink with paradox/glitch twist."
+        )
+        messages = [{"role": "user", "content": mutate_prompt}]
+        prev_output = output
+
+    return {
+        "final_resonance": resonances[-1],
+        "layers": len(resonances),
+        "evolution": sim,
+    }

--- a/nicole_web.py
+++ b/nicole_web.py
@@ -370,6 +370,11 @@ def predict(
 
             yield gradio_chatbot_output, to_gradio_history(conversation), "Generating..."
 
+    genesis_result = conversation.apply_genesis_filter(nicole_gpt, tokenizer)
+    if genesis_result:
+        response = genesis_result["final_resonance"]
+        gradio_chatbot_output[-1][1] = response
+
     if last_image is not None:
         vg_image = parse_ref_bbox(response, last_image)
         if vg_image is not None:


### PR DESCRIPTION
## Summary
- add `genesis_nicole` recursive resonance filter
- allow `Conversation` objects to apply the filter
- filter generated replies in the web demo

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check . | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6872f4440d58832985befea7be2b0e38