### PR TITLE
Fix Python 3.10 collections patch

### DIFF
--- a/Nicole/__init__.py
+++ b/Nicole/__init__.py
@@ -1,13 +1,28 @@
 # Copyright (c) 2025 Arianna Method
 
-# check if python version is above 3.10
+"""Nicole package initialization.
+
+This module ensures compatibility with Python 3.10+ by patching the
+``collections`` module so that legacy names continue to be available.
+The patch is applied only once per interpreter session. Set the environment
+variable ``NICOLE_DEBUG_PATCH`` to ``1`` to receive a warning when the patch
+is executed.
+"""
+
+import os
 import sys
+import warnings
 
 if sys.version_info >= (3, 10):
-    print("Python version is above 3.10, patching the collections module.")
-    # Monkey patch collections
     import collections
     import collections.abc
 
-    for type_name in collections.abc.__all__:
-        setattr(collections, type_name, getattr(collections.abc, type_name))
+    if not getattr(collections, "_nicole_patched", False):
+        for type_name in collections.abc.__all__:
+            setattr(collections, type_name, getattr(collections.abc, type_name))
+        setattr(collections, "_nicole_patched", True)
+        if os.getenv("NICOLE_DEBUG_PATCH"):
+            warnings.warn(
+                "Python >= 3.10 detected; patched the collections module for backward compatibility.",
+                stacklevel=2,
+            )


### PR DESCRIPTION
## Summary
- only patch `collections` once
- document compatibility patch in `Nicole/__init__`
- allow optional warning with `NICOLE_DEBUG_PATCH`

## Testing
- `pre-commit run --files Nicole/__init__.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873012ca59483298c360b546c21e4f0