### PR TITLE
Move conversation demo to examples

### DIFF
--- a/Nicole/models/conversation.py
+++ b/Nicole/models/conversation.py
@@ -157,10 +157,5 @@ register_conv_template(
 register_conv_template(Conversation(name="plain", sep_style=SeparatorStyle.PLAIN))
 register_conv_template(Conversation(name="alignment", sep_style=SeparatorStyle.ALIGNMENT))
 
-# ───────────────────────── Demo ───────────────────────────────────────────
-if __name__ == "__main__":
-    demo = get_conv_template("nicole")
-    demo.append_message(demo.roles[0], "Hello Nicole, who are you?")
-    demo.append_message(demo.roles[1], None)
-    print(demo.get_prompt())
+
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,25 @@ python nicole_web.py --model_name Nicole --local_path <checkpoint>
 - Additional UI elements and prompt conversions reside in `Nicole/serve/inference.py` and `Nicole/serve/app_modules/presets.py`.
 - When experimenting with new prompts or response styles, the conversation templates in `conversation.py` are the safest place to inject them.
 
+### Simple conversation template example
+
+The script `examples/conversation_demo.py` illustrates how to build a prompt using the default template:
+
+```python
+from Nicole.models.conversation import get_conv_template
+
+conv = get_conv_template("nicole")
+conv.append_message(conv.roles[0], "Hello Nicole, who are you?")
+conv.append_message(conv.roles[1], None)
+print(conv.get_prompt())
+```
+
+Run it with:
+
+```bash
+python examples/conversation_demo.py
+```
+
 ## Files that may be removed
 
 Some files are kept only for reference and are not required for running Nicole:

--- a/examples/conversation_demo.py
+++ b/examples/conversation_demo.py
@@ -1,0 +1,7 @@
+from Nicole.models.conversation import get_conv_template
+
+if __name__ == "__main__":
+    conv = get_conv_template("nicole")
+    conv.append_message(conv.roles[0], "Hello Nicole, who are you?")
+    conv.append_message(conv.roles[1], None)
+    print(conv.get_prompt())


### PR DESCRIPTION
## Summary
- remove the `__main__` block from `conversation.py`
- add the same snippet to `examples/conversation_demo.py`
- document the example in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873093d29008329a1dfe48b730eeba0